### PR TITLE
kd - copy backend CRUD operations from team01 for the menu item review table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,133 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for MenuItemReviews */
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  @Operation(summary = "List all menu item reviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allReviews() {
+    Iterable<MenuItemReview> menuitemreviews = menuItemReviewRepository.findAll();
+    return menuitemreviews;
+  }
+
+  @Operation(summary = "Create a new review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postReview(
+      @Parameter(name = "itemId") @RequestParam long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars") @RequestParam int stars,
+      @Parameter(name = "dateReviewed", description = "in iso format, e.g. YYYY-MM-DDTHH:MM:SS")
+          @RequestParam("dateReviewed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments) {
+
+    log.info("dateReviewed={}", dateReviewed);
+
+    MenuItemReview review = new MenuItemReview();
+    review.setItemId(itemId);
+    review.setReviewerEmail(reviewerEmail);
+    review.setStars(stars);
+    review.setDateReviewed(dateReviewed);
+    review.setComments(comments);
+
+    MenuItemReview savedReview = menuItemReviewRepository.save(review);
+
+    return savedReview;
+  }
+
+  /**
+   * Get a single review by id
+   *
+   * @param id the id of the review
+   * @return a MenuItemReview
+   */
+  @Operation(summary = "Get a single review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public MenuItemReview getById(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return menuItemReview;
+  }
+
+  /**
+   * Update a single review
+   *
+   * @param id id of the review to update
+   * @param incoming the new review
+   * @return the updated review object
+   */
+  @Operation(summary = "Update a single review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReview.setItemId(incoming.getItemId());
+    menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+    menuItemReview.setStars(incoming.getStars());
+    menuItemReview.setDateReviewed(incoming.getDateReviewed());
+    menuItemReview.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(menuItemReview);
+
+    return menuItemReview;
+  }
+
+  /**
+   * Delete a review
+   *
+   * @param id the id of the review to delete
+   * @return a message indicating the review was deleted
+   */
+  @Operation(summary = "Delete a MenuItemReview")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItemReview(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReviewRepository.delete(menuItemReview);
+    return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a Menu Item Review, */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreviews")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The MenuItemReviewRepository is a repository for MenuItemReview entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "katelyn-dang",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEWS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEWS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INTEGER"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "MENUITEMREVIEWS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,333 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+  @MockitoBean MenuItemReviewRepository menuItemReviewRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "test@example.com")
+                .param("stars", "5")
+                .param("dateReviewed", "2026-04-27T12:30:00")
+                .param("comments", "Great food")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "test@example.com")
+                .param("stars", "5")
+                .param("dateReviewed", "2026-04-27T12:30:00")
+                .param("comments", "Great food")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
+    LocalDateTime dateReviewed1 = LocalDateTime.parse("2026-04-27T12:30:00");
+
+    MenuItemReview review1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("test1@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed1)
+            .comments("Great food")
+            .build();
+
+    LocalDateTime dateReviewed2 = LocalDateTime.parse("2026-04-28T13:45:00");
+
+    MenuItemReview review2 =
+        MenuItemReview.builder()
+            .itemId(2)
+            .reviewerEmail("test2@example.com")
+            .stars(4)
+            .dateReviewed(dateReviewed2)
+            .comments("Pretty good")
+            .build();
+
+    ArrayList<MenuItemReview> expectedReviews = new ArrayList<>();
+    expectedReviews.addAll(Arrays.asList(review1, review2));
+
+    when(menuItemReviewRepository.findAll()).thenReturn(expectedReviews);
+
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().isOk()).andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findAll();
+
+    String expectedJson = mapper.writeValueAsString(expectedReviews);
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+    LocalDateTime dateReviewed = LocalDateTime.parse("2026-04-27T12:30:00");
+
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("test@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed)
+            .comments("Great food")
+            .build();
+
+    when(menuItemReviewRepository.save(eq(review))).thenReturn(review);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/menuitemreview/post")
+                    .param("itemId", "1")
+                    .param("reviewerEmail", "test@example.com")
+                    .param("stars", "5")
+                    .param("dateReviewed", "2026-04-27T12:30:00")
+                    .param("comments", "Great food")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).save(review);
+
+    String expectedJson = mapper.writeValueAsString(review);
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview").param("id", "7")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_by_id_when_id_exists() throws Exception {
+
+    LocalDateTime dateReviewed = LocalDateTime.parse("2026-04-27T12:30:00");
+
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("test@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed)
+            .comments("Great food")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(review));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/menuitemreview").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+
+    String expectedJson = mapper.writeValueAsString(review);
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_cannot_get_by_id_when_id_does_not_exist() throws Exception {
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    mockMvc.perform(get("/api/menuitemreview").param("id", "7")).andExpect(status().isNotFound());
+
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+
+    LocalDateTime dateReviewed1 = LocalDateTime.parse("2026-04-27T12:30:00");
+    LocalDateTime dateReviewed2 = LocalDateTime.parse("2026-04-28T13:45:00");
+
+    MenuItemReview reviewOrig =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("old@example.com")
+            .stars(3)
+            .dateReviewed(dateReviewed1)
+            .comments("Original comment")
+            .build();
+
+    MenuItemReview reviewEdited =
+        MenuItemReview.builder()
+            .itemId(2)
+            .reviewerEmail("new@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed2)
+            .comments("Updated comment")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(reviewEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(reviewOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    verify(menuItemReviewRepository, times(1)).save(reviewEdited);
+
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+
+    LocalDateTime dateReviewed = LocalDateTime.parse("2026-04-27T12:30:00");
+
+    MenuItemReview reviewEdited =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("test@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed)
+            .comments("Great food!")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(reviewEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_menuitemreview() throws Exception {
+
+    LocalDateTime dateReviewed = LocalDateTime.parse("2026-04-27T12:30:00");
+
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("test@example.com")
+            .stars(5)
+            .dateReviewed(dateReviewed)
+            .comments("Great food")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(review));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+    verify(menuItemReviewRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_delete_menuitemreview_that_does_not_exist() throws Exception {
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
Closes #29 

In this PR, we copy over the entity, repository, controller, and controller tests, and db migration file (i.e. the entire backend CRUD functionality) for the MenuItemReview table, from the previous project team01-s26-15

# To test

1. Fire up application on localhost or dokku
2. Login
3. Go to swagger
4. Try each of the endpoints in the following screenshot

<img width="1578" height="660" alt="image" src="https://github.com/user-attachments/assets/0308b5eb-cdba-447b-be72-f81258dd6554" />
