### PR TITLE
kd - add placeholder pages for Index, Edit, Create for MenuItemReviews

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,54 +29,35 @@ function App() {
 
   return (
     <Routes>
-      <Route exact path="/" element={<HomePage />} />
-      <Route exact path="/profile" element={<ProfilePage />} />
+      <Route path="/" element={<HomePage />} />
+      <Route path="/profile" element={<ProfilePage />} />
 
       {hasRole(currentUser, "ROLE_ADMIN") && (
-        <Route exact path="/admin/users" element={<AdminUsersPage />} />
+        <Route path="/admin/users" element={<AdminUsersPage />} />
       )}
 
       {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route exact path="/ucsbdates" element={<UCSBDatesIndexPage />} />
-        </>
+        <Route path="/ucsbdates" element={<UCSBDatesIndexPage />} />
       )}
 
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
-          <Route
-            exact
-            path="/ucsbdates/edit/:id"
-            element={<UCSBDatesEditPage />}
-          />
-          <Route
-            exact
-            path="/ucsbdates/create"
-            element={<UCSBDatesCreatePage />}
-          />
+          <Route path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
+          <Route path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
         </>
       )}
 
-      {/* ✅ FIXED: Added MenuItemReviews index route */}
-      {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route
-            exact
-            path="/menuItemReviews"
-            element={<MenuItemReviewsIndexPage />}
-          />
-        </>
-      )}
+      {/* ✅ FIX: Index route ALWAYS available */}
+      <Route path="/menuItemReviews" element={<MenuItemReviewsIndexPage />} />
 
+      {/* Admin-only create/edit */}
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
-            exact
             path="/menuItemReviews/edit/:id"
             element={<MenuItemReviewsEditPage />}
           />
           <Route
-            exact
             path="/menuItemReviews/create"
             element={<MenuItemReviewsCreatePage />}
           />
@@ -84,20 +65,16 @@ function App() {
       )}
 
       {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route exact path="/restaurants" element={<RestaurantIndexPage />} />
-        </>
+        <Route path="/restaurants" element={<RestaurantIndexPage />} />
       )}
 
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
-            exact
             path="/restaurants/edit/:id"
             element={<RestaurantEditPage />}
           />
           <Route
-            exact
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
           />
@@ -105,20 +82,16 @@ function App() {
       )}
 
       {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
-        </>
+        <Route path="/placeholder" element={<PlaceholderIndexPage />} />
       )}
 
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
-            exact
             path="/placeholder/edit/:id"
             element={<PlaceholderEditPage />}
           />
           <Route
-            exact
             path="/placeholder/create"
             element={<PlaceholderCreatePage />}
           />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,9 +14,6 @@ import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 import MenuItemReviewsIndexPage from "main/pages/MenuItemReviews/MenuItemReviewsIndexPage";
 import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
 import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
-import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
-import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
 import UCSBOrganizationsCreatePage from "main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage";
@@ -29,6 +26,10 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import { hasRole, useCurrentUser } from "main/utils/useCurrentUser";
 
@@ -48,59 +49,36 @@ function App() {
       )}
 
       {hasRole(currentUser, "ROLE_USER") && (
-        <Route path="/ucsbdates" element={<UCSBDatesIndexPage />} />
+        <>
+          <Route path="/ucsbdates" element={<UCSBDatesIndexPage />} />
+          <Route path="/restaurants" element={<RestaurantIndexPage />} />
+
+          <Route
+            path="/menuItemReviews"
+            element={<MenuItemReviewsIndexPage />}
+          />
+
+          <Route
+            path="/ucsborganizations"
+            element={<UCSBOrganizationsIndexPage />}
+          />
+
+          <Route path="/placeholder" element={<PlaceholderIndexPage />} />
+
+          <Route path="/articles" element={<ArticlesIndexPage />} />
+
+          <Route
+            path="/diningcommonsmenuitem"
+            element={<UCSBDiningCommonsMenuItemIndexPage />}
+          />
+        </>
       )}
 
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
           <Route path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
-        </>
-      )}
 
-      {/* ✅ FIX: Index route ALWAYS available */}
-      <Route path="/menuItemReviews" element={<MenuItemReviewsIndexPage />} />
-
-      {/* Admin-only create/edit */}
-      {hasRole(currentUser, "ROLE_ADMIN") && (
-        <>
-          <Route
-            path="/menuItemReviews/edit/:id"
-            element={<MenuItemReviewsEditPage />}
-          />
-          <Route
-            path="/menuItemReviews/create"
-            element={<MenuItemReviewsCreatePage />}
-          />
-        </>
-      )}
-
-      {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route exact path="/articles" element={<ArticlesIndexPage />} />
-        </>
-      )}
-      {hasRole(currentUser, "ROLE_ADMIN") && (
-        <>
-          <Route
-            exact
-            path="/articles/edit/:id"
-            element={<ArticlesEditPage />}
-          />
-          <Route
-            exact
-            path="/articles/create"
-            element={<ArticlesCreatePage />}
-          />
-        </>
-      )}
-
-      {hasRole(currentUser, "ROLE_USER") && (
-        <Route path="/restaurants" element={<RestaurantIndexPage />} />
-      )}
-
-      {hasRole(currentUser, "ROLE_ADMIN") && (
-        <>
           <Route
             path="/restaurants/edit/:id"
             element={<RestaurantEditPage />}
@@ -109,56 +87,25 @@ function App() {
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
           />
-        </>
-      )}
 
-      {hasRole(currentUser, "ROLE_USER") && (
-        <Route path="/placeholder" element={<PlaceholderIndexPage />} />
-        <>
           <Route
-            exact
-            path="/diningcommonsmenuitem"
-            element={<UCSBDiningCommonsMenuItemIndexPage />}
+            path="/menuItemReviews/edit/:id"
+            element={<MenuItemReviewsEditPage />}
           />
           <Route
-            exact
-            path="/ucsborganizations"
-            element={<UCSBOrganizationsIndexPage />}
+            path="/menuItemReviews/create"
+            element={<MenuItemReviewsCreatePage />}
           />
-        </>
-      )}
-      {hasRole(currentUser, "ROLE_ADMIN") && (
-        <>
+
           <Route
-            exact
-            path="/diningcommonsmenuitem/edit/:id"
-            element={<UCSBDiningCommonsMenuItemEditPage />}
-          />
-          <Route
-            exact
-            path="/diningcommonsmenuitem/create"
-            element={<UCSBDiningCommonsMenuItemCreatePage />}
-          />
-          <Route
-            exact
             path="/ucsborganizations/edit/:orgCode"
             element={<UCSBOrganizationsEditPage />}
           />
           <Route
-            exact
             path="/ucsborganizations/create"
             element={<UCSBOrganizationsCreatePage />}
           />
-        </>
-      )}
-      {hasRole(currentUser, "ROLE_USER") && (
-        <>
-          <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
-        </>
-      )}
 
-      {hasRole(currentUser, "ROLE_ADMIN") && (
-        <>
           <Route
             path="/placeholder/edit/:id"
             element={<PlaceholderEditPage />}
@@ -166,6 +113,18 @@ function App() {
           <Route
             path="/placeholder/create"
             element={<PlaceholderCreatePage />}
+          />
+
+          <Route path="/articles/edit/:id" element={<ArticlesEditPage />} />
+          <Route path="/articles/create" element={<ArticlesCreatePage />} />
+
+          <Route
+            path="/diningcommonsmenuitem/edit/:id"
+            element={<UCSBDiningCommonsMenuItemEditPage />}
+          />
+          <Route
+            path="/diningcommonsmenuitem/create"
+            element={<UCSBDiningCommonsMenuItemCreatePage />}
           />
         </>
       )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,14 +31,17 @@ function App() {
     <Routes>
       <Route exact path="/" element={<HomePage />} />
       <Route exact path="/profile" element={<ProfilePage />} />
+
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <Route exact path="/admin/users" element={<AdminUsersPage />} />
       )}
+
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/ucsbdates" element={<UCSBDatesIndexPage />} />
         </>
       )}
+
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
@@ -53,7 +56,19 @@ function App() {
           />
         </>
       )}
-            {hasRole(currentUser, "ROLE_ADMIN") && (
+
+      {/* ✅ FIXED: Added MenuItemReviews index route */}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/menuItemReviews"
+            element={<MenuItemReviewsIndexPage />}
+          />
+        </>
+      )}
+
+      {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
             exact
@@ -67,11 +82,13 @@ function App() {
           />
         </>
       )}
+
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/restaurants" element={<RestaurantIndexPage />} />
         </>
       )}
+
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
@@ -86,11 +103,13 @@ function App() {
           />
         </>
       )}
+
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
         </>
       )}
+
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import MenuItemReviewsIndexPage from "main/pages/MenuItemReviews/MenuItemReviewsIndexPage";
+import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
+import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -46,6 +50,20 @@ function App() {
             exact
             path="/ucsbdates/create"
             element={<UCSBDatesCreatePage />}
+          />
+        </>
+      )}
+            {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/menuItemReviews/edit/:id"
+            element={<MenuItemReviewsEditPage />}
+          />
+          <Route
+            exact
+            path="/menuItemReviews/create"
+            element={<MenuItemReviewsCreatePage />}
           />
         </>
       )}

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,0 +1,38 @@
+const menuItemReviewFixtures = {
+  oneReview: {
+    id: 1,
+    itemId: 2,
+    reviewerEmail: "katelyndang@ucsb.edu",
+    stars: 5,
+    dateReviewed: "2026-05-04T15:10:10",
+    comments: "Very good food!",
+  },
+  threeReviews: [
+    {
+      id: 1,
+      itemId: 2,
+      reviewerEmail: "katelyndang@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2026-05-04T15:10:10",
+      comments: "Very good food!",
+    },
+    {
+      id: 2,
+      itemId: 1,
+      reviewerEmail: "katelyndang@ucsb.edu",
+      stars: 2,
+      dateReviewed: "2025-06-10T16:25:10",
+      comments: "It was okay",
+    },
+    {
+      id: 3,
+      itemId: 3,
+      reviewerEmail: "katelyndang@ucsb.edu",
+      stars: 4,
+      dateReviewed: "2025-05-06T18:21:15",
+      comments: "Would eat again",
+    },
+  ],
+};
+
+export { menuItemReviewFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -71,6 +71,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/menuItemReviews">
+                    Menu Item Reviews
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewsCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsEditPage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewsEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewsIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/menuItemReviews/create">Create</a>
+        </p>
+        <p>
+          <a href="/menuItemReviews/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewsCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Create page not yet implemented");
+
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewsEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/menuItemReviews/edit/1"]}>
+          <Routes>
+            <Route
+              path="/menuItemReviews/edit/:id"
+              element={<MenuItemReviewsEditPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Edit page not yet implemented");
+
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewsIndexPage from "main/pages/MenuItemReviews/MenuItemReviewsIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewsIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "frontend/src"
+  },
+  "include": ["frontend/src"]
+}


### PR DESCRIPTION
Closes #33 

Does not depend on any other PR to be merged first.

In this PR, we add placeholder features for Index, Create, and Edit pages for the menuitemreviews table. 

You can see this at the moment on this dokku instance (after you login): 
https://team02-katelyn-dang-dev.dokku-15.cs.ucsb.edu/

Screenshots:
<img width="1210" height="610" alt="image" src="https://github.com/user-attachments/assets/764d98e3-570e-433a-84a7-2c865040d28e" />
<img width="1482" height="574" alt="image" src="https://github.com/user-attachments/assets/538d4527-2e41-4ca4-b57e-ce60bf3001d9" />
<img width="1450" height="478" alt="image" src="https://github.com/user-attachments/assets/55969940-5e86-4b9b-be2a-e2004fd0868e" />
