### PR TITLE
Fix Menu Item Reviews route casing

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -61,7 +61,7 @@ export default function AppNavbar({
                   UCSB Organizations
                 </Nav.Link>
 
-                <Nav.Link as={Link} to="/menuItemReviews">
+                <Nav.Link as={Link} to="/menuitemreviews">
                   Menu Item Reviews
                 </Nav.Link>
 


### PR DESCRIPTION
In this PR, I had to fix the route casing for Menu Item Reviews pages by changing all occurrences of:

/menuItemReviews to:
/menuitemreviews