### PR TITLE
Add RecommendationRequest integration and e2e tests

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestIT {
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
+    // arrange
+    RecommendationRequest expected =
+        RecommendationRequest.builder()
+            .id(1L)
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("professor@ucsb.edu")
+            .explanation("I need a recommendation letter for graduate school.")
+            .dateRequested(LocalDateTime.parse("2026-05-10T12:00:00"))
+            .dateNeeded(LocalDateTime.parse("2026-06-01T12:00:00"))
+            .done(false)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/RecommendationRequest/post")
+                    .param("requesterEmail", "student@ucsb.edu")
+                    .param("professorEmail", "professor@ucsb.edu")
+                    .param("explanation", "I need a recommendation letter for graduate school.")
+                    .param("dateRequested", "2026-05-10T12:00:00")
+                    .param("dateNeeded", "2026-06-01T12:00:00")
+                    .param("done", "false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(expected);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+    assertEquals(1, recommendationRequestRepository.count());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_recommendation_request() throws Exception {
+    setupUser(true);
+
+    page.navigate("http://localhost:8080/recommendationrequest/create");
+
+    assertThat(page.getByText("Create New Recommendation Request")).isVisible();
+
+    page.getByTestId("RecommendationRequestForm-requesterEmail").fill("student@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-professorEmail").fill("professor@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-explanation")
+        .fill("I need a recommendation letter for graduate school.");
+    page.getByTestId("RecommendationRequestForm-dateRequested").fill("2026-05-10T12:00");
+    page.getByTestId("RecommendationRequestForm-dateNeeded").fill("2026-06-01T12:00");
+
+    page.getByTestId("RecommendationRequestForm-submit").click();
+
+    page.waitForURL("**/recommendationrequest");
+
+    assertThat(page.getByText("Index page not yet implemented")).isVisible();
+  }
+}


### PR DESCRIPTION
Adds Team03 tests for RecommendationRequest.

- Adds RecommendationRequestIT for POST /api/RecommendationRequest/post
- Adds RecommendationRequestWebIT for creating a RecommendationRequest through the frontend create form
- Closes #130
Closes #129